### PR TITLE
Enhance movie app UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,3 +120,11 @@
     @apply bg-background text-foreground;
   }
 }
+
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+.hide-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,12 +22,14 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased font-sans bg-background text-foreground`}
+      >
+        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
           <Navbar />
           <main className="container mx-auto p-4">{children}</main>
         </ThemeProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
-import MovieCard from '@/components/ui/MovieCard'
+import Hero from '@/components/hero'
+import MovieCarousel from '@/components/movie-carousel'
 import { fetchTrendingMovies } from '@/lib/utils'
 
 interface Movie {
@@ -12,11 +13,12 @@ export default async function Home() {
   const data = await fetchTrendingMovies()
   const movies: Movie[] = data.results ?? []
 
+  const [featured, ...rest] = movies
+
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-      {movies.map((movie) => (
-        <MovieCard key={movie.id} movie={movie} />
-      ))}
+    <div className="space-y-8">
+      {featured && <Hero movie={featured} />}
+      <MovieCarousel movies={rest} title="Trending" />
     </div>
   )
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import MovieCard from '@/components/ui/MovieCard'
+import { Input } from '@/components/ui/input'
 import { searchMovies } from '@/lib/utils'
 
 interface Movie {
@@ -28,11 +29,11 @@ export default function SearchPage() {
 
   return (
     <div>
-      <input
+      <Input
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Search movies..."
-        className="w-full p-2 rounded border mb-4 text-black dark:text-white"
+        className="mb-4"
       />
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
         {results.map((movie) => (

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,0 +1,42 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { Star } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { Movie } from '@/components/ui/MovieCard'
+
+export default function Hero({ movie }: { movie: Movie & { backdrop_path?: string; overview?: string } }) {
+  return (
+    <section className="relative h-[60vh] w-full overflow-hidden rounded-xl shadow-md">
+      {movie.backdrop_path && (
+        <Image
+          src={`https://image.tmdb.org/t/p/original${movie.backdrop_path}`}
+          alt={movie.title}
+          fill
+          priority
+          className="object-cover"
+        />
+      )}
+      <div className="absolute inset-0 bg-background/60 flex flex-col justify-end p-6">
+        <h1 className="text-4xl md:text-5xl font-bold mb-2">
+          {movie.title}
+        </h1>
+        {movie.overview && (
+          <p className="mb-4 max-w-lg text-muted-foreground line-clamp-3">
+            {movie.overview}
+          </p>
+        )}
+        <div className="mb-4 flex items-center gap-2 text-yellow-400">
+          <Star className="size-5" /> {movie.vote_average?.toFixed(1)}
+        </div>
+        <div className="flex gap-2">
+          <Button asChild>
+            <Link href={`/movie/${movie.id}`}>Watch Now</Link>
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href={`/movie/${movie.id}`}>Trailer</Link>
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/movie-carousel.tsx
+++ b/src/components/movie-carousel.tsx
@@ -1,0 +1,15 @@
+import MovieCard, { Movie } from '@/components/ui/MovieCard'
+
+export default function MovieCarousel({ movies, title }: { movies: Movie[]; title: string }) {
+  if (!movies.length) return null
+  return (
+    <section className="space-y-2">
+      <h2 className="text-xl font-bold mb-2">{title}</h2>
+      <div className="flex overflow-x-auto space-x-4 pb-2 hide-scrollbar">
+        {movies.map((movie) => (
+          <MovieCard key={movie.id} movie={movie} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,15 +1,51 @@
 'use client'
 
 import Link from 'next/link'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Search } from 'lucide-react'
 import ThemeToggle from './theme-toggle'
+import { Input } from '@/components/ui/input'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 
 export default function Navbar() {
+  const [query, setQuery] = useState('')
+  const router = useRouter()
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!query.trim()) return
+    router.push(`/search?query=${encodeURIComponent(query)}`)
+  }
+
   return (
-    <nav className="p-4 flex items-center justify-between border-b">
-      <Link href="/" className="font-semibold">TMDB Movies</Link>
+    <nav className="sticky top-0 z-50 flex items-center justify-between gap-4 bg-background px-6 py-4 shadow-md">
+      <Link href="/" className="text-lg font-bold tracking-tight">
+        AGENCY
+      </Link>
+      <div className="hidden md:flex items-center gap-6 text-sm font-medium">
+        <Link href="/">New</Link>
+        <Link href="/">Movies</Link>
+        <Link href="/">Series</Link>
+        <Link href="/">Cartoons</Link>
+      </div>
+      <form onSubmit={onSubmit} className="mx-4 flex-1 max-w-sm">
+        <div className="relative">
+          <Search className="absolute left-2 top-2.5 size-4 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search..."
+            className="pl-8"
+          />
+        </div>
+      </form>
       <div className="flex items-center gap-2">
-        <Link href="/search" className="text-sm underline">Search</Link>
         <ThemeToggle />
+        <Avatar>
+          <AvatarImage src="" alt="User" />
+          <AvatarFallback>U</AvatarFallback>
+        </Avatar>
       </div>
     </nav>
   )

--- a/src/components/ui/MovieCard.tsx
+++ b/src/components/ui/MovieCard.tsx
@@ -11,7 +11,7 @@ export interface Movie {
 export default function MovieCard({ movie }: { movie: Movie }) {
   return (
     <Link href={`/movie/${movie.id}`}>
-      <div className="rounded-xl shadow-md hover:scale-105 transition">
+      <div className="rounded-xl shadow-md hover:scale-105 transition cursor-pointer">
         <Image
           src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
           alt={movie.title}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,34 @@
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+import { cn } from "@/lib/utils"
+
+const Avatar = AvatarPrimitive.Root
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full rounded-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }


### PR DESCRIPTION
## Summary
- set dark mode as the default theme
- add modern sticky navbar with search and avatar
- create hero section for featured movie
- implement horizontal movie carousel
- style search with shadcn Input
- polish movie cards and add scrollbar hiding utilities

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856ca74f1d8832280c6b0b8d735d74d